### PR TITLE
WIP - Use Enum type for ip2long version option

### DIFF
--- a/lib/networks.py
+++ b/lib/networks.py
@@ -3,7 +3,7 @@ import ipcalc
 import socket
 import struct
 from binascii import hexlify
-from processor import ip2long, node
+from processor import AddressFormats, ip2long, node
 
 
 def add_all(c):
@@ -23,9 +23,9 @@ def add_all_rfc_1918(c):
         ipv4_netmask_dec = int(str(ipv4).split("/")[1])
         node_id = node(c)
 
-        row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, 4),
-               str(ipv4), None, ip2long(ipv4_netmask, 4), str(ipv4_netmask),
-               None, ip2long(ipv4_gateway, 4), str(ipv4_gateway),
+        row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, AddressFormats.IPv4),
+               str(ipv4), None, ip2long(ipv4_netmask, AddressFormats.IPv4), str(ipv4_netmask),
+               None, ip2long(ipv4_gateway, AddressFormats.IPv4), str(ipv4_gateway),
                None, int(ipv4_netmask_dec), 0]
 
         c.execute(

--- a/lib/processor.py
+++ b/lib/processor.py
@@ -13,6 +13,12 @@ SYNTAX = {
   "^[A-Z]": "network"
 }
 
+def enum(**enums):
+    return type('Enum', (), enums)
+
+
+AddressFormats = enum(IPv4 = 4, IPv6 = 6)
+
 _current_domain = None
 _current_v6_base = None
 _domains = set()
@@ -51,10 +57,9 @@ def master_network(l, c, r):
 
         name = '%s@%s' % (_current_domain, short_name)
 
-        row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, 4),
-               str(ipv4), str(ipv6), ip2long(
-                   ipv4_netmask, 4), str(ipv4_netmask),
-               str(ipv6_netmask), ip2long(ipv4_gateway, 4), str(ipv4_gateway),
+        row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, AddressFormats.IPv4),
+               str(ipv4), str(ipv6), ip2long(ipv4_netmask, AddressFormats.IPv4), str(ipv4_netmask),
+               str(ipv6_netmask), ip2long(ipv4_gateway, AddressFormats.IPv4), str(ipv4_gateway),
                str(ipv6_gateway), int(ipv4_netmask_dec), 1]
 
         c.execute(
@@ -78,9 +83,7 @@ def host(l, c, network_id):
     row = [
         node_id,
         name,
-        ip2long(
-            ipv4_addr,
-            4),
+        ip2long(ipv4_addr, AddressFormats.IPv4),
         ipv4_addr,
         ipv6_addr,
         network_id]
@@ -112,9 +115,9 @@ def network(l, c, r):
 
     name = '%s@%s' % (_current_domain, short_name)
 
-    row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, 4),
-           str(ipv4), str(ipv6), ip2long(ipv4_netmask, 4), str(ipv4_netmask),
-           str(ipv6_netmask), ip2long(ipv4_gateway, 4), str(ipv4_gateway),
+    row = [node_id, name, short_name, vlan, terminator, ip2long(ipv4, AddressFormats.IPv4),
+           str(ipv4), str(ipv6), ip2long(ipv4_netmask, AddressFormats.IPv4), str(ipv4_netmask),
+           str(ipv6_netmask), ip2long(ipv4_gateway, AddressFormats.IPv4), str(ipv4_gateway),
            str(ipv6_gateway), int(ipv4_netmask_dec), 1]
     c.execute(
         'INSERT INTO network VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
@@ -164,7 +167,7 @@ def node(c):
 
 def ip2long(ip, version):
     ip = str(ip).split("/")[0]
-    if version == 4:
+    if version == AddressFormats.IPv4:
         packedIP = socket.inet_aton(ip)
         return struct.unpack("!L", packedIP)[0]
     else:

--- a/tests/TestParser.py
+++ b/tests/TestParser.py
@@ -12,8 +12,15 @@ import processor
 class TestParser(BaseTestCase, unittest.TestCase):
 
     def testParseIPv4(self):
-        self.assertEquals(processor.ip2long('8.8.8.8', 4), 134744072)
-        self.assertEquals(processor.ip2long('77.80.251.247/32', 4), 1297153015)
+        self.assertEquals(
+            processor.ip2long('8.8.8.8', processor.AddressFormats.IPv4),
+            134744072
+        )
+        self.assertEquals(
+            processor.ip2long('77.80.251.247/32',
+                processor.AddressFormats.IPv4),
+            1297153015
+        )
 
     def testParserMapping(self):
         l = ["""#$ d20--b.event.dreamhack.local\t\t\t10.0.3.45


### PR DESCRIPTION
Introduce an enum type (should be compatible with all Python versions) for `AddressFormats`, which makes all code involving `ip2long` calls more readable.
